### PR TITLE
Refresh website on release

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -8,18 +8,7 @@ on:
     types: [created]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-#      - run: npm ci
-#      - run: npm test
-
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +16,15 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-#      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+  update-flow:
+    runs-on: ubuntu-latest
+    name: Node Red Flow Refresh
+    needs: publish-npm
+    steps:
+    - name: POST
+      uses: hacksore/node-red-update-flow@v1
+      with:
+        repo: 'node-red-contrib-bluelinky'

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -25,6 +25,6 @@ jobs:
     needs: publish-npm
     steps:
     - name: POST
-      uses: hacksore/node-red-update-flow@v1
+      uses: hacksore/node-red-flow@v1
       with:
         repo: 'node-red-contrib-bluelinky'


### PR DESCRIPTION
It should send a POST request to the flow site to force the reindex of a package to get the latest showing up in the node-red UI palette. 
 
Can't be 100% certain it works so we'll have to test it next release 😅.